### PR TITLE
Add initial JOIN command

### DIFF
--- a/lib/command_views.rb
+++ b/lib/command_views.rb
@@ -106,6 +106,10 @@ module CommandViews
     server_msg(406, nick, "No such nick/channel")
   end
 
+  def render_no_such_channel(channel)
+    server_msg(403, channel, "No such channel, make sure you've authenticated.")
+  end
+
   def render_set_away
     server_msg(306, "You have been marked as being away")
   end

--- a/lib/commands/join_command.rb
+++ b/lib/commands/join_command.rb
@@ -1,0 +1,15 @@
+class JoinCommand < Command
+  register_command :JOIN
+
+  def set_data(args)
+    @target = args.first
+  end
+
+  def valid?
+    !!@target and registered?
+  end
+
+  def execute!
+    send_reply(render_no_such_channel(@target)) unless authenticated? && find_channel(@target)
+  end
+end

--- a/spec/commands/join_command_spec.rb
+++ b/spec/commands/join_command_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe JoinCommand do
+  it "should not send anything when authenticated and joining existing channel" do
+    irc_connection = mock(:irc_connection, :nick => 'Otto', :registered? => true, :authenticated? => true)
+    irc_connection.stub!(:find_channel).and_return(true)
+    irc_connection.should_not_receive(:send_reply).with(/No such channel/)
+
+    cmd = JoinCommand.new(irc_connection)
+    cmd.set_data(["#irc/ottotest"])
+    cmd.valid?.should be_true
+    cmd.execute!
+  end
+
+  it "should send error if authenticated, but channel does not exist" do
+    irc_connection = mock(:irc_connection, :nick => 'Otto', :registered? => true, :authenticated? => true)
+    irc_connection.stub!(:find_channel).and_return(false)
+    irc_connection.should_receive(:send_reply).with(/403 Otto #test :No such channel/)
+
+    cmd = JoinCommand.new(irc_connection)
+    cmd.set_data(["#test"])
+    cmd.valid?.should be_true
+    cmd.execute!
+  end
+
+  it "should send error if not authenticated" do
+    irc_connection = mock(:irc_connection, :nick => 'Otto', :registered? => true, :authenticated? => false)
+    irc_connection.should_receive(:send_reply).with(/403 Otto #test :No such channel/)
+
+    cmd = JoinCommand.new(irc_connection)
+    cmd.set_data(["#test"])
+    cmd.valid?.should be_true
+    cmd.execute!
+  end
+end


### PR DESCRIPTION
Return "No such channel" error if not authenticated or if the channel doesn't exist.
Otherwise clients keep the channel "active" after reconnect making it really difficult
to notice that you are actually not be authenticated anymore.
