### PR TITLE
make PASS command work for authentication

### DIFF
--- a/lib/commands/pass_command.rb
+++ b/lib/commands/pass_command.rb
@@ -2,17 +2,17 @@ class PassCommand < Command
   register_command :PASS
 
   def set_data(args)
-    @email = args.first
-    @password = args[1]
+    @password = args.first
   end
 
   def valid?
-    (!registered? && !@password.nil? && !@email.nil?)
+    (!registered? && !@password.nil?)
   end
 
   def execute!
     irc_connection.password = @password
-    irc_connection.email = @email
+    # just save the password, the PASS command is issued before USER/NICK,
+    #   so we can't do anything yet.
   end
 
 end

--- a/lib/commands/user_command.rb
+++ b/lib/commands/user_command.rb
@@ -5,6 +5,7 @@ class UserCommand < Command
 
   def set_data(args)
     if args.size == 4
+      @email = args.first
       @user_name = args.first.sub(/@.*/, '')
       @real_name = args.last
     end
@@ -16,7 +17,7 @@ class UserCommand < Command
 
   def execute!
     if @user_name.match(USERNAME_REGEX)
-      irc_connection.email ||= "#{@user_name}@unknown"
+      irc_connection.email ||= @email
       irc_connection.real_name = @real_name
       irc_connection.ping! if registered? and !irc_connection.last_ping_sent
     else


### PR DESCRIPTION
The previous work on this (https://github.com/flowdock/oulu/pull/31) didn't result in a working implementation. The attached code works for me when testing with LimeChat (a fairly generic IRC client for OS X) and follows the RFC for IRC on the PASS command (http://www.irchelp.org/irchelp/rfc/chapter4.html#c4_1_1). The command sequence the client issued was:

03:05:39 app.1     | PASS *********
03:05:39 app.1     | NICK a
03:05:39 app.1     | USER user@*****.com 0 \* c

The comments in pull request 31 seem to be attempting to auth on /connect (which seems pretty different).

Comments about the changes:

pass_command.rb:
- email should be ignored by this command. the RFC specifies 'PASS pass', with no email.

user_command.rb
- email should be taken directly from the user input
