### PR TITLE
UTF8 fixes

### DIFF
--- a/lib/irc_parser.rb
+++ b/lib/irc_parser.rb
@@ -17,6 +17,9 @@ module IrcParser
   protected
 
   def self.parse_line(raw_data)
+    raw_data.force_encoding(Encoding::UTF_8)
+    raw_data.force_encoding(Encoding::Windows_1252).encode!(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => '?') unless raw_data.valid_encoding?
+
     data = raw_data.chomp.split(' ').compact
     return [nil, []] if data.size == 0
 

--- a/spec/irc_parser_spec.rb
+++ b/spec/irc_parser_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe IrcParser do
@@ -47,6 +48,21 @@ describe IrcParser do
     klass, args = IrcParser.parse("motd")
     klass.should == MotdCommand
     args.should be_empty
+  end
+
+  it "should return UTF-8" do
+    command = "WHOIS test".force_encoding(Encoding::ASCII_8BIT)
+    klass, args = IrcParser.parse(command)
+    klass.should == WhoisCommand
+    args.first.encoding.should == Encoding::UTF_8
+  end
+
+  it "should encode LATIN1 to UTF-8" do
+    command = 'WHOIS tår'.encode(Encoding::ISO8859_1).force_encoding(Encoding::ASCII_8BIT)
+    klass, args = IrcParser.parse(command)
+    klass.should == WhoisCommand
+    args.first.encoding.should == Encoding::UTF_8
+    args.first.should == 'tår'
   end
 
   it "should survive empty messages" do


### PR DESCRIPTION
Client commands came in as ASCII_8BIT and comparisons with UTF-8 strings would not match. Always encode input as UTF-8.
