### PR TITLE
Fix the rendering of the messages that start a thread in the new thread format

### DIFF
--- a/lib/events/message_event.rb
+++ b/lib/events/message_event.rb
@@ -24,7 +24,7 @@ class MessageEvent < FlowdockEvent
   end
 
   def render_message
-    if @message["thread_id"]
+    if @message["thread"] && @message["id"] != @message["thread"]["initial_message"]
       "#{thread_header(@message["thread"])} << #{@message["content"]}"
     else
       @message["content"]

--- a/spec/fixtures/flowdock_events/legacy_message_event.json
+++ b/spec/fixtures/flowdock_events/legacy_message_event.json
@@ -1,0 +1,1 @@
+{"id":907,"app":"chat","flow":"irc:ottotest","event":"message","sent":1334660642345,"attachments":[],"uuid":"KE1tqxXhhmNMVkKC","user":"1","content":"test","tags":[]}

--- a/spec/fixtures/flowdock_events/message_event.json
+++ b/spec/fixtures/flowdock_events/message_event.json
@@ -1,1 +1,1 @@
-{"id":907,"app":"chat","flow":"irc:ottotest","event":"message","sent":1334660642345,"attachments":[],"uuid":"KE1tqxXhhmNMVkKC","user":"1","content":"test","tags":[]}
+{"thread_id":"L3AnpcexMyWSkRDYPznxvE7xnI7", "id":907,"app":"chat","flow":"irc:ottotest","event":"message","sent":1334660642345,"attachments":[],"uuid":"KE1tqxXhhmNMVkKC","user":"1","content":"test","tags":[],"thread":{"body":"","external_url":"","status":null,"fields":[],"actions":[],"created_at":"2012-04-17T11:04:02.345Z","title":"test","initial_message":907,"internal_comments":1}}

--- a/spec/flowdock_event_spec.rb
+++ b/spec/flowdock_event_spec.rb
@@ -25,6 +25,16 @@ describe FlowdockEvent do
       event.process
     end
 
+    it "should process legacy chat message" do
+      message_event = message_hash('legacy_message_event')
+      expect(@irc_connection).to receive(:remove_outgoing_message).with(message_event).and_return(false)
+
+      expect(@irc_connection).to receive(:send_reply).with(":Otto!otto@example.com PRIVMSG #{@channel.irc_id} :test").once
+      event = FlowdockEvent.from_message(@irc_connection, message_event)
+      expect(event).to be_valid
+      event.process
+    end
+
     it "should process standard chat message from external user" do
       message_event = message_hash('message_from_external_user_event')
       expect(@irc_connection).to receive(:remove_outgoing_message).with(message_event).and_return(false)
@@ -48,6 +58,14 @@ describe FlowdockEvent do
 
     it "should render standard chat message" do
       message_event = message_hash('message_event')
+
+      event = FlowdockEvent.from_message(@irc_connection, message_event)
+      expect(event).to be_valid
+      expect(event.render).to eq(":Otto!otto@example.com PRIVMSG #{@channel.irc_id} :test")
+    end
+
+    it "should render legacy chat message" do
+      message_event = message_hash('legacy_message_event')
 
       event = FlowdockEvent.from_message(@irc_connection, message_event)
       expect(event).to be_valid


### PR DESCRIPTION
Previously all the messages in the new thread format was rendered with the thread title, which in case of a chat message that starts a thread is usually the same as the content:

```
<Nick> [test message]: test message
```

This changes it so that the title is not shown for the first message of a thread.