### PR TITLE
Remove links to inbox items

### DIFF
--- a/lib/flowdock_event.rb
+++ b/lib/flowdock_event.rb
@@ -59,21 +59,13 @@ class FlowdockEvent
   def team_inbox_event(integration, *description)
     description.collect do |str|
       "[#{integration}] #{str}"
-    end.push(team_inbox_link(integration)).join("\n")
-  end
-
-  def team_inbox_link(integration)
-    "[#{integration}] Show in Flowdock: #{team_inbox_url(@message['id'])}"
-  end
-
-  def team_inbox_url(item_id)
-    @target.web_url + "/inbox/#{item_id}"
+    end.join("\n")
   end
 
   def thread_event(author, thread, *description)
     description.map do |str|
       "#{thread_header(thread)} #{author}: #{str}"
-    end.push(thread_link(thread, author)).join("\n")
+    end.join("\n")
   end
 
   def thread_header(thread)
@@ -86,14 +78,6 @@ class FlowdockEvent
     else
       "[#{thread_title}]"
     end
-  end
-
-  def thread_link(thread, author)
-    "#{thread_header(thread)} #{author}: Show in Flowdock: #{thread_url(@message['thread_id'])}"
-  end
-
-  def thread_url(id)
-    @target.web_url + "/threads/#{id}"
   end
 
   def first_line(text)

--- a/spec/flowdock_event_spec.rb
+++ b/spec/flowdock_event_spec.rb
@@ -143,7 +143,7 @@ describe FlowdockEvent do
         "vcs:github/push" => [
             "[Github] master @ https://github.com/flowdock/oulu updated",
             "[Github] * b2c2857: Merge branch 'master' of github.com:flowdock/oulu <tuomas.silen@nodeta.fi>",
-            "[Github] * c70bcf7: Support ISON command for NickServ <tuomas.silen@nodeta.fi>",
+            "[Github] * c70bcf7: Support ISON command for NickServ <tuomas.silen@nodeta.fi>"
           ],
         "vcs:github/push_semi_large" => [
             "[Github] master @ https://github.com/testfoe/API-test updated",

--- a/spec/flowdock_event_spec.rb
+++ b/spec/flowdock_event_spec.rb
@@ -129,197 +129,156 @@ describe FlowdockEvent do
     describe "team inbox messages" do
       {
         "email" => [
-            "[Email] arttu.tervo@gmail.com: This is the email subject",
-            "[Email] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/2182",
+            "[Email] arttu.tervo@gmail.com: This is the email subject"
           ],
         "rss" => [
-            "[RSS] [[Satisfaction]: New topics and replies for Word]: New reply: \"Freezing Tiles\"",
-            "[RSS] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/123367",
+            "[RSS] [[Satisfaction]: New topics and replies for Word]: New reply: \"Freezing Tiles\""
           ],
         "vcs:github/push_new_branch" => [
-            "[Github] testfoe created branch new-branch @ https://github.com/testfoe/API-test",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148056",
+            "[Github] testfoe created branch new-branch @ https://github.com/testfoe/API-test"
           ],
         "vcs:github/push_delete_branch" => [
-            "[Github] testfoe deleted branch stupid-feature @ https://github.com/testfoe/API-test",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148113",
+            "[Github] testfoe deleted branch stupid-feature @ https://github.com/testfoe/API-test"
           ],
         "vcs:github/push" => [
             "[Github] master @ https://github.com/flowdock/oulu updated",
             "[Github] * b2c2857: Merge branch 'master' of github.com:flowdock/oulu <tuomas.silen@nodeta.fi>",
             "[Github] * c70bcf7: Support ISON command for NickServ <tuomas.silen@nodeta.fi>",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/5706106",
           ],
         "vcs:github/push_semi_large" => [
             "[Github] master @ https://github.com/testfoe/API-test updated",
             "[Github] * 22d38bd: Merge pull request #3 from testfoe/new-feature <testfoe@example.com>",
             "[Github] * 6db2b04: More descriptive readme <testfoe@example.com>",
             "[Github] * 6db2b04: More descriptive readme <testfoe@example.com>",
-            "[Github] * 6db2b04: This is the fourth commit in this push <testfoe@example.com>",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/147958",
+            "[Github] * 6db2b04: This is the fourth commit in this push <testfoe@example.com>"
           ],
         "vcs:github/push_large" => [
             "[Github] master @ https://github.com/testfoe/API-test updated",
             "[Github] * 22d38bd: Merge pull request #3 from testfoe/new-feature <testfoe@example.com>",
             "[Github] * 6db2b04: More descriptive readme <testfoe@example.com>",
             "[Github] * 6db2b04: More descriptive readme <testfoe@example.com>",
-            "[Github] .. 2 more commits ..",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/147958",
+            "[Github] .. 2 more commits .."
           ],
         "vcs:github/commit_comment" => [
             "[Github] testfoe commented #22d38bd @ https://github.com/testfoe/API-test/commit/22d38bdc5f#commitcomment-666757",
-            "[Github] > This is the comment body.",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148005",
+            "[Github] > This is the comment body."
           ],
         "vcs:github/pull_request_open" => [
-            "[Github] arttu opened pull request https://github.com/flowdock/flowdock-web/issues/190",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/5706152",
+            "[Github] arttu opened pull request https://github.com/flowdock/flowdock-web/issues/190"
           ],
         "vcs:github/pull_request_merge" => [
-            "[Github] testfoe merged pull request https://github.com/testfoe/API-test/issues/3",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148184",
+            "[Github] testfoe merged pull request https://github.com/testfoe/API-test/issues/3"
           ],
         "vcs:github/pull_request_close" => [
-            "[Github] testfoe closed pull request https://github.com/testfoe/API-test/issues/4",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148175",
+            "[Github] testfoe closed pull request https://github.com/testfoe/API-test/issues/4"
           ],
         "vcs:github/pull_request_comment" => [
             "[Github] testfoe commented pull request https://github.com/testfoe/API-test/issues/3",
-            "[Github] > Commenting pull request. More text is better since then we can see how the UI scales. And other things of that nature. Just like Arnold Schwarzenegger would say.",
-            "[Github] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/148150",
+            "[Github] > Commenting pull request. More text is better since then we can see how the UI scales. And other things of that nature. Just like Arnold Schwarzenegger would say."
           ],
         "svn:subversion/commit" => [
-            "[Subversion] arttutervo updated 'foo' with r1: Svn directory structure.",
-            "[Subversion] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1234567",
+            "[Subversion] arttutervo updated 'foo' with r1: Svn directory structure."
           ],
         "svn:subversion/multiline_commit" => [
-            "[Subversion] arttutervo updated 'foo' with r2: Added a README,",
-            "[Subversion] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1234570",
+            "[Subversion] arttutervo updated 'foo' with r2: Added a README,"
           ],
         "svn:subversion/branch_create" => [
-            "[Subversion] arttutervo created branch ultimate @ foo",
-            "[Subversion] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1234568",
+            "[Subversion] arttutervo created branch ultimate @ foo"
           ],
         "svn:subversion/branch_delete" => [
-            "[Subversion] arttutervo deleted branch ultimate @ foo",
-            "[Subversion] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1234569",
+            "[Subversion] arttutervo deleted branch ultimate @ foo"
           ],
         "jira:jira/create" => [
-            "[JIRA] Otto Hilska created issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/36",
+            "[JIRA] Otto Hilska created issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5"
           ],
         "jira:jira/update" => [
-            "[JIRA] Otto Hilska updated issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/57",
+            "[JIRA] Otto Hilska updated issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5"
           ],
         "jira:jira/resolve" => [
-            "[JIRA] Ville Lautanala resolved issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/64",
+            "[JIRA] Ville Lautanala resolved issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5"
           ],
         "jira:jira/close" => [
-            "[JIRA] Otto Hilska closed issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/46",
+            "[JIRA] Otto Hilska closed issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5"
           ],
         "jira:jira/comment" => [
             "[JIRA] Ville Lautanala commented issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] > Now that I'm working on this, this is simply a comment (no editing involved).",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/70",
+            "[JIRA] > Now that I'm working on this, this is simply a comment (no editing involved)."
           ],
         "jira:jira/start_work" => [
-            "[JIRA] Ville Lautanala started working on issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5",
-            "[JIRA] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/75",
+            "[JIRA] Ville Lautanala started working on issue: Otto's new bug http://localhost:2990//jira/browse/TEST-5"
           ],
         "confluence:confluence/create" => [
-            "[Confluence] admin created page in Demonstration Space: Some page http://localhost:1990/confluence/display/ds/Somepage",
-            "[Confluence] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/220",
+            "[Confluence] admin created page in Demonstration Space: Some page http://localhost:1990/confluence/display/ds/Somepage"
           ],
         "confluence:confluence/update" => [
-            "[Confluence] admin updated page in Demonstration Space: Home http://localhost:1990/confluence/display/ds/Home",
-            "[Confluence] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1277",
+            "[Confluence] admin updated page in Demonstration Space: Home http://localhost:1990/confluence/display/ds/Home"
           ],
         "confluence:confluence/delete" => [
-            "[Confluence] admin deleted page in Demonstration Space: Some page",
-            "[Confluence] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/199",
+            "[Confluence] admin deleted page in Demonstration Space: Some page"
           ],
         "confluence:confluence/comment_create" => [
             "[Confluence] mutru commented page in Demonstration Space: Home http://localhost:1990/confluence/display/ds/Home",
-            "[Confluence] > Test comment",
-            "[Confluence] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1280",
+            "[Confluence] > Test comment"
           ],
         "uservoice:uservoice/suggestion" => [
             "[Uservoice] New suggestion: Test suggestion",
-            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/48828"
+            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion"
           ],
         "uservoice:uservoice/comment" => [
             "[Uservoice] New comment on: Test suggestion",
             "[Uservoice] > Test comment",
-            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/48918"
+            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion"
           ],
         "uservoice:uservoice/article" => [
             "[Uservoice] New article: Is this a new article?",
-            "[Uservoice] http://test.uservoice.com/knowledgebase/articles/-is-this-a-new-article-",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50045"
+            "[Uservoice] http://test.uservoice.com/knowledgebase/articles/-is-this-a-new-article-"
           ],
         "uservoice:uservoice/forum" => [
             "[Uservoice] New forum: Test forum",
-            "[Uservoice] http://test.uservoice.com/forums/-test-forum",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50051"
+            "[Uservoice] http://test.uservoice.com/forums/-test-forum"
           ],
         "uservoice:uservoice/kudo" => [
             "[Uservoice] Test Message Sender received Kudos! from Test Kudo Sender on Test subject",
-            "[Uservoice] http://test.uservoice.com/admin/tickets/1",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50066"
+            "[Uservoice] http://test.uservoice.com/admin/tickets/1"
           ],
         "uservoice:uservoice/suggestion_status_changed" => [
             "[Uservoice] Test suggestion: completed",
-            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50079"
+            "[Uservoice] http://test.uservoice.com/forums/739109572-test-forum/suggestions/-test-suggestion"
           ],
         "uservoice:uservoice/ticket" => [
             "[Uservoice] New ticket: Test subject",
-            "[Uservoice] http://test.uservoice.com/admin/tickets/1",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50085"
+            "[Uservoice] http://test.uservoice.com/admin/tickets/1"
           ],
         "uservoice:uservoice/ticket_reply" => [
             "[Uservoice] New reply on: Test subject",
-            "[Uservoice] http://test.uservoice.com/admin/tickets/1",
-            "[Uservoice] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/50091"
+            "[Uservoice] http://test.uservoice.com/admin/tickets/1"
           ],
         "pivotaltracker:pivotaltracker/story_create" => [
             "[Pivotal Tracker] Otto Hilska added \"The greatest story ever\"",
-            "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/7877517",
-            "[Pivotal Tracker] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1431",
+            "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/7877517"
           ],
         "pivotaltracker:pivotaltracker/multi_story_edit" => [
             "[Pivotal Tracker] Otto Hilska edited 3 stories",
             "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/6363057",
             "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/6363061",
-            "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/7877517",
-            "[Pivotal Tracker] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/1474",
+            "[Pivotal Tracker] https://www.pivotaltracker.com/story/show/7877517"
           ],
         "twitter" => [
-            "[Twitter] FlowdockRumors: /server -ssl http://t.co/wGqvQmbP 6697",
-            "[Twitter] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/153642",
+            "[Twitter] FlowdockRumors: /server -ssl http://t.co/wGqvQmbP 6697"
           ],
         "twitter:multiline_tweet" => [
             "[Twitter] FlowdockRumors: /server -ssl http://t.co/wGqvQmbP 6697",
-            "KICK Otto",
-            "[Twitter] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/153642",
+            "KICK Otto"
           ],
         "zendesk" => [
             "[Zendesk] Arttu Tervo commented ticket",
-            "[Zendesk] http://testcompany.zendesk.com/tickets/2",
-            "[Zendesk] Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/inbox/173643",
+            "[Zendesk] http://testcompany.zendesk.com/tickets/2"
           ],
         "activity" => [
-            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: Test message with link",
-            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/threads/Eg46ehQSRpWW5XSoX2tFm-t55Sk",
+            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: Test message with link"
           ],
         "discussion" => [
-            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: commented on ticket",
-            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: Show in Flowdock: https://www.#{IrcServer::FLOWDOCK_DOMAIN}/app/irc/ottotest/threads/Eg46ehQSRpWW5XSoX2tFm-t55Sk",
+            "[Oulu Test app (Source name): Test thread] Oskari Virtanen: commented on ticket"
         ]
       }.each_pair do |_event, content|
         event, fixture = (_event.match(':') && _event.split(':') || [_event, _event])


### PR DESCRIPTION
The "Show in Flowdock" links for each inbox event cause a lot of noise and provide little value, so let's just remove them.