### PR TITLE
Support presence events

### DIFF
--- a/lib/events/presence_event.rb
+++ b/lib/events/presence_event.rb
@@ -1,0 +1,24 @@
+class PresenceEvent < FlowdockEvent
+  register_event "presence"
+
+  STATES = {
+      0 => :offline,
+      1000000 => :idle,
+      2000000 => :active
+  }
+
+  def process
+    content = @message['content']
+    irc_connection.channels.values.each do |channel|
+      channel_user = channel.find_user_by_id(content['user_id'])
+      if channel_user
+        channel_user.presence = STATES[content['state']]
+        channel_user.last_presence_update = Time.parse(content['updated_at'])
+      end
+    end
+  end
+
+  def valid?
+    !!@message['content']
+  end
+end

--- a/lib/flowdock_connection.rb
+++ b/lib/flowdock_connection.rb
@@ -30,7 +30,7 @@ class FlowdockConnection
     end
 
     @source = EventMachine::EventSource.new((ENV["FLOWDOCK_UNSECURE_HTTP"] ? "http" : "https") + "://stream.#{IrcServer::FLOWDOCK_DOMAIN}/flows",
-      { 'filter' => flows.join(','), 'active' => active, 'user' => 1 },
+      { 'filter' => flows.join(','), 'active' => active, 'user' => 1, 'presence' => 1 },
       { 'Accept' => 'text/event-stream',
         'authorization' => [username, password] })
 

--- a/lib/flowdock_event.rb
+++ b/lib/flowdock_event.rb
@@ -1,4 +1,5 @@
 require 'filter/strip_html_filter'
+require 'time'
 
 class FlowdockEvent
   class UnsupportedMessageError < StandardError; end
@@ -31,7 +32,7 @@ class FlowdockEvent
       target = irc_connection.find_user_by_id(message['to'])
     end
 
-    user = irc_connection.find_user_by_id(message['user'])
+    user = irc_connection.find_user_by_id(message['user'] || message['user_id'])
 
     processed_message = MessageProcessor.new(message).perform
     event_type.new(irc_connection, target, user, processed_message)

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,5 +1,5 @@
 class User
-  attr_accessor :id, :nick, :name, :email, :status, :last_activity
+  attr_accessor :id, :nick, :name, :email, :status, :last_activity, :presence, :last_presence_update
 
   def initialize(hash)
     @id = hash['id'].to_i
@@ -7,6 +7,8 @@ class User
     @name = hash['name']
     @email = hash['email']
     @status = hash['status']
+    @presence = nil
+    @last_presence_update = 0
     update_last_activity(hash['last_activity'])
   end
 
@@ -35,7 +37,25 @@ class User
     @last_activity = Time.at(ms_epoch / 1000)
   end
 
+  def active?
+    @presence == :active
+  end
+
+  def idle?
+    @presence == :idle
+  end
+
+  def offline?
+    @presence == :offline
+  end
+
   def idle_time
-    Time.now - @last_activity
+    if active?
+      0
+    elsif idle? || offline?
+      Time.now - @last_presence_update
+    else
+      Time.now - @last_activity
+    end
   end
 end

--- a/spec/fixtures/flowdock_events/presence_event.json
+++ b/spec/fixtures/flowdock_events/presence_event.json
@@ -1,0 +1,1 @@
+{"event":"presence","content":{"user_id":1,"state":2000000,"updated_at":"2015-05-27T13:09:38.780Z"},"user_id":1}

--- a/spec/flowdock_event_spec.rb
+++ b/spec/flowdock_event_spec.rb
@@ -317,6 +317,25 @@ describe FlowdockEvent do
     end
   end
 
+  describe "presence" do
+    before(:each) do
+      expect(@irc_connection).to receive(:find_user_by_id).once do |arg|
+        @channel.find_user_by_id(arg)
+      end
+    end
+
+    it "should update user's state" do
+      message_event = message_hash('presence_event')
+      expect(@irc_connection).to receive(:channels).and_return({ @channel.id => @channel })
+      event = FlowdockEvent.from_message(@irc_connection, message_event)
+      expect(event).to be_valid
+      event.process
+      user = @channel.find_user_by_id(1)
+      expect(user.presence).to eq(:active)
+      expect(user.last_presence_update.to_s).to eq("2015-05-27 13:09:38 UTC")
+    end
+  end
+
   describe "adding and removing flows" do
     it "should part channel when blocked" do
       remove_event = message_hash('flow_remove_event')


### PR DESCRIPTION
Use presence events to maintain user's state and idle time. Old activity events are also still supported.